### PR TITLE
Output cleanup

### DIFF
--- a/lib/envjasmine.js
+++ b/lib/envjasmine.js
@@ -146,15 +146,21 @@ EnvJasmine.disableColor = (function (env) {
     return EnvJasmine.disableColor || (env == "WIN");
 }(EnvJasmine.environment));
 
-if (EnvJasmine.disableColor) {
-    EnvJasmine.green = "";
-    EnvJasmine.red = "";
-    EnvJasmine.endColor = "";
-} else {
-    EnvJasmine.green = "\033[32m";
-    EnvJasmine.red = "\033[31m";
-    EnvJasmine.endColor = "\033[0m";
-}
+(function() {
+    if (EnvJasmine.disableColor) {
+        EnvJasmine.green = function(msg) { return msg; };
+        EnvJasmine.red = function(msg) { return msg; };
+        EnvJasmine.plain = function(msg) { return msg; };
+    } else {
+        var green = "\033[32m",
+            red = "\033[31m",
+            end = "\033[0m";
+
+        EnvJasmine.green = function(msg) { return green + msg + end; };
+        EnvJasmine.red = function(msg) { return red + msg + end; };
+        EnvJasmine.plain = function(msg) { return msg; };
+    }
+}());
 EnvJasmine.results = [];
 
 // Load the envjasmine environment
@@ -213,13 +219,13 @@ EnvJasmine.loadConfig = function () {
 
     if (EnvJasmine.results.length > 0) {
         print("\n");
-        print(EnvJasmine.red + EnvJasmine.results.join("\n\n") + EnvJasmine.endColor);
+        print(EnvJasmine.red(EnvJasmine.results.join("\n\n")));
         print("\n");
     }
 
-    print(EnvJasmine.green + "Passed: " + EnvJasmine.passedCount + EnvJasmine.endColor);
-    print(EnvJasmine.red + "Failed: " + EnvJasmine.failedCount + EnvJasmine.endColor);
-    print("Total : " + EnvJasmine.totalCount);
+    print(EnvJasmine.green("Passed: " + EnvJasmine.passedCount));
+    print(EnvJasmine.red("Failed: " + EnvJasmine.failedCount));
+    print(EnvJasmine.plain("Total : " + EnvJasmine.totalCount));
 
     if (EnvJasmine.failedCount > 0) {
         System.exit(1);

--- a/lib/jasmine-rhino-reporter/jasmine-rhino-reporter.js
+++ b/lib/jasmine-rhino-reporter/jasmine-rhino-reporter.js
@@ -1,16 +1,6 @@
 importPackage(java.lang);
 
 var RhinoReporter = function() {
-    var green = EnvJasmine.green,
-        red = EnvJasmine.red,
-        endColor = EnvJasmine.endColor;
-
-    if (EnvJasmine.disableColor) {
-        green = "";
-        red = "";
-        endColor = "";
-    }
-
     return {
         reportRunnerStarting: function(runner) {
         },
@@ -29,12 +19,12 @@ var RhinoReporter = function() {
 
         reportSpecResults: function(spec) {
             if (spec.results().passed()) {
-                System.out.print(green + "." + endColor);
+                System.out.print(EnvJasmine.green("."));
             } else {
                 var i, msg,
                     specResults = spec.results().getItems();
 
-                System.out.print(red + "F" + endColor);
+                System.out.print(EnvJasmine.red("F"));
 
                 msg = [
                     "FAILED",


### PR DESCRIPTION
Just some general cleanup to the output since specs are now run in their own scopes. This gets back to a single list of "." or "F" for all specs in the library, adds the spec file where the failing test was to the list of failing tests (wasn't possible before specs running in their own scope), and some general code cleanup.
