### PR TITLE
Updated EnvJasmine.loadFactory to print a message when a file is not found.

### DIFF
--- a/lib/envjasmine.js
+++ b/lib/envjasmine.js
@@ -57,9 +57,9 @@ EnvJasmine.loadFactory = function(scope) {
         try {
             fileIn = new FileReader(normalizedPath);
             EnvJasmine.cx.evaluateReader(scope, fileIn, normalizedPath, 0, null);
-        }
-        finally {
             fileIn.close();
+        } catch (e) {
+            print('Could not read file: ' + normalizedPath );
         }
     };
 };


### PR DESCRIPTION
The loadFactory method was throwing an unhandled exception (cannot call "close" of undefined) whenever a file was not found; while this caused the test to fail, it also caused issues for code where it was expected that the file being loaded dynamically may not be present.  

This small change updates the loadFactory method to print a "Could not read file" message, allowing the test to continue.
