### PR TITLE
Corrects a problem with accessing local files on Windows systems

### DIFF
--- a/lib/envjs/env.rhino.1.2.js
+++ b/lib/envjs/env.rhino.1.2.js
@@ -288,7 +288,7 @@ function __trim__( str ){
  * Specifies the location of the cookie file
  */
 Envjs.cookieFile = function(){
-    return 'file://'+Envjs.homedir+'/.cookies';
+    return 'file://'+(Envjs.homedir.charAt(0) === '/'?'':'/')+Envjs.homedir+'/.cookies';
 };
 
 /**
@@ -1128,7 +1128,7 @@ Envjs.uri = function(path, base) {
     // if base is still empty, then we are in QA mode loading local
     // files.  Get current working directory
     if (!base) {
-        base = 'file://' +  Envjs.getcwd() + '/';
+        base = 'file://' + (Envjs.getcwd().charAt(0) === '/'?'':'/') + Envjs.getcwd() + '/';
     }
     // handles all cases if path is abosulte or relative to base
     // 3rd arg is "false" --> remove fragments


### PR DESCRIPTION
In Windows, the file URI protocol requires three slashes, instead of 2. 
