### PR TITLE
Small change to fix reporting of missing spec files

### DIFF
--- a/lib/envjasmine.js
+++ b/lib/envjasmine.js
@@ -241,8 +241,14 @@ EnvJasmine.loadConfig = function () {
             EnvJasmine.cx.evaluateReader(EnvJasmine.currentScope, fileIn, EnvJasmine.specs[i], 0, null);
             EnvJasmine.cx.evaluateString(EnvJasmine.currentScope, 'window.location.assign(["file://", EnvJasmine.libDir, "envjasmine.html"].join(EnvJasmine.SEPARATOR));', 'Executing '+EnvJasmine.specs[i], 0, null);
         }
+        catch (e) {
+            print("Problem opening ", EnvJasmine.specFile);
+            print(e.javaException.getMessage());
+        }
         finally {
-            fileIn.close();
+            if(fileIn) {
+                fileIn.close();
+            }
         }
     }
 


### PR DESCRIPTION
Currently, EnvJasmine reports 'cannot call "close" method of undefined' if you give it a filepath to a non-existent file.

This change makes the message a lot clear as to what went wrong.
